### PR TITLE
fix: session mgmt, post logout, authZ endpoint's custom query param

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       dockerfile: ./docker/docker-files/nginxplus-ubuntu18.04/Dockerfile
     image: nginxplus_oidc_auth0_ubuntu18.04
     ports:
-      - 443:443
+      - 12000:12000
     volumes:
       - type: bind
         source: ./

--- a/oidc.js
+++ b/oidc.js
@@ -5,16 +5,17 @@
  */
 
 // Constants for common error message. These will be cleaned up.
-var ERR_CFG_VARS              = 'OIDC missing configuration variables: ';
-var ERR_AC_TOKEN              = 'OIDC Access Token validation error: ';
-var ERR_ID_TOKEN              = 'OIDC ID Token validation error: ';
-var ERR_IDP_AUTH              = 'OIDC unexpected response from IdP in code exchange';
-var ERR_TOKEN_RES             = 'OIDC AuthZ code sent but token response is not JSON. ';
-var ERR_X_CLIENT_ID_COOKIE    = 'X-Client-Id should be in cookie';
-var ERR_X_CLIENT_ID_NOT_FOUND = 'X-Client-Id not found in the IdP app';
-var WRN_SESSION               = 'OIDC session is invalid';
-var INF_REFRESH_TOKEN         = 'OIDC refresh success, updating tokens for ';
-var INF_REPLACE_TOKEN         = 'OIDC replacing previous refresh token (';
+var ERR_CFG_VARS      = 'OIDC missing configuration variables';
+var ERR_AC_TOKEN      = 'OIDC Access Token validation error';
+var ERR_ID_TOKEN      = 'OIDC ID Token validation error';
+var ERR_IDP_AUTH      = 'OIDC unexpected response from IdP in code exchange';
+var ERR_TOKEN_RES     = 'OIDC AuthZ code sent but token response is not JSON';
+var ERR_CLIENT_ID     = 'Check if cookie is removed, and client_id is there';
+var ERR_IDP_APP_NAME  = 'IdP app is not set in $oidc_app_name';
+var WRN_SESSION       = 'OIDC session is invalid';
+var INF_SESSION       = 'OIDC session is valid';
+var INF_REFRESH_TOKEN = 'OIDC refresh success, updating tokens for ';
+var INF_REPLACE_TOKEN = 'OIDC replacing previous refresh token';
 
 // Flag to check if there is still valid session cookie. It is used by auth()
 // and validateIdToken().
@@ -133,10 +134,24 @@ function validateIdToken(r) {
 //
 // - https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowTokenValidation
 // - https://openid.net/specs/openid-connect-core-1_0.html#ImplicitTokenValidation
+//
 // - This function is called by the location of `_access_token_validation` which
 //   is called by either OIDC code exchange or refersh token request.
+//
 // - The 'aud' claim isn't contained in general ID token from Amazon Cognito,
 //   although we can add it. Hence, the claim isn't part of this validation.
+//
+// - This function is for the case when you want to validate the token within
+//   NGINX layer to following the spec. of OpenID Connect Core 1.0. 
+//
+// - But, this token is mostly validated by using one of following options.
+//
+//   + Option 1. validate a token (assumtion: JWT format) by using
+//               a NGINX auth_jwt directive to validate it via IdP URI.
+//     auth_jwt "" token=$access_token;
+//     auth_jwt_key_request /_jwks_uri;
+//
+//   + Option 2. validate a token by using IdP token introspection endpoint.
 //
 function validateAccessToken(r) {
     var missingClaims = []
@@ -208,7 +223,6 @@ function generateCustomEndpoint(r, uri, isEnableCustomPath, paths) {
     var res   = '';
     var key   = '';
     var isKey = false;
-    r.log('### paths: ' + paths)
     var items = JSON.parse(paths);
     for (var i = 0; i < uri.length; i++) {
         switch (uri[i]) {
@@ -271,7 +285,7 @@ function startIdPAuthZ(r) {
         }
     }
     if (missingConfig.length) {
-        r.error(ERR_CFG_VARS + '$oidc_' + missingConfig.join(' $oidc_'));
+        r.error(ERR_CFG_VARS + ': $oidc_' + missingConfig.join(' $oidc_'));
         r.return(500, r.variables.internal_error_message);
         return;
     }
@@ -335,7 +349,7 @@ function handleSuccessfulRefreshResponse(r, res) {
         // Update new refresh token to key/value store if we got a new one.
         r.log(INF_REFRESH_TOKEN + r.variables.cookie_session_id);
         if (r.variables.refresh_token != tokenset.refresh_token) {
-            r.log(INF_REPLACE_TOKEN + r.variables.refresh_token + 
+            r.log(INF_REPLACE_TOKEN + ' (' + r.variables.refresh_token + 
                     ') with new value: ' + tokenset.refresh_token);
             r.variables.refresh_token = tokenset.refresh_token;
         }
@@ -473,7 +487,7 @@ function handleSuccessfulTokenResponse(r, res) {
                                      '; ' + r.variables.oidc_cookie_flags;
         r.return(302, r.variables.redirect_base + r.variables.cookie_auth_redir);
     } catch (e) {
-        r.error(ERR_TOKEN_RES + res.responseBody);
+        r.error(ERR_TOKEN_RES + ' ' + res.responseBody);
         r.return(502);
     }
 }
@@ -512,7 +526,8 @@ function getAuthZArgs(r) {
                       '&client_id='                + r.variables.oidc_client + 
                       '&redirect_uri='             + redirectURI + 
                       // uncomment when to need claims of access token in Auth0.
-                      // '&audience='              + 'https://{{domain}}}/api/v2/' +
+                    //   '&audience='              + 'https://{{domain}}}/api/v2/' +
+                      '&audience='              + 'https://dev-s4i2bm4p.us.auth0.com/api/v2/' +
                       '&nonce='                    + nonceHash;
     var cookieFlags = r.variables.oidc_cookie_flags;
     r.headersOut['Set-Cookie'] = [
@@ -704,7 +719,7 @@ function isValidRequiredClaims(r, msgPrefix, missingClaims) {
             }
         }
         if (missingClaims.length) {
-            r.error(msgPrefix + 'missing claim(s) ' + missingClaims.join(' '));
+            r.error(msgPrefix + ': missing claim(s) ' + missingClaims.join(' '));
             return false;
         }
     } catch (e) {
@@ -733,6 +748,8 @@ function isValidTokenSet(r, tokenset) {
         // The validateIdToken() logs error so that r.error() isn't used.
         return isErr;
     }
+    // The access token is mostly validated by IdP using auth_jwt directive.
+    // This can be used when you want to validate the token set in NGINX.
     if (r.variables.access_token_validation_enable == 1 &&
         !isValidToken(r, '/_access_token_validation', tokenset.access_token)) {
         // The validateAccessToken() logs error so that r.error() isn't used.
@@ -804,12 +821,12 @@ function isValidSession(r) {
 // the session cookie could play from any client (browsers or command line).
 //
 function validateSession(r) {
-    if (r.variables.session_validation_enable == 1 && !isValidSession(r)) {
+    if (!isValidSession(r)) {
         r.warn(WRN_SESSION)
         r.return(401, '{"message": "' + WRN_SESSION + '"}\n')
         return false;
     }
-    r.return(200, '{"message": "' + WRN_SESSION + '"}\n') 
+    r.return(200, '{"message": "' + INF_SESSION + '"}\n') 
     return true;
 }
 
@@ -820,14 +837,13 @@ function validateSession(r) {
 function isValidXClientId(r) {
     if (r.variables.client_id_validation_enable == 1) {
         if (!r.variables.cookie_client_id) {
-            r.warn(ERR_X_CLIENT_ID_COOKIE)
-            r.return(400, '{"message": "' + ERR_X_CLIENT_ID_COOKIE + '"}\n')
+            r.warn(ERR_CLIENT_ID)
+            r.return(400, '{"message": "' + ERR_CLIENT_ID + '"}\n')
             return false
         }
         if (r.variables.oidc_app_name == '') {
-            var errMsg = ERR_X_CLIENT_ID_NOT_FOUND + ': ' + r.variables.cookie_client_id;
-            r.warn(errMsg)
-            r.return(404, '{"message": "' + errMsg + '"}\n')
+            r.warn(ERR_IDP_APP_NAME)
+            r.return(404, '{"message": "' + ERR_IDP_APP_NAME + '"}\n')
             return false
         }
     }

--- a/oidc.js
+++ b/oidc.js
@@ -192,7 +192,8 @@ function logout(r) {
     // Call the IDP logout endpoint with custom query parameters
     // if the IDP doesn't support RP-initiated logout.
     } else {
-        queryParams = generateQueryParams(r.variables.oidc_logout_query_params);
+        queryParams = '?' + generateQueryParams(
+            r.variables.oidc_logout_query_params);
     }
     r.variables.session_id    = '-';
     r.variables.id_token      = '-';
@@ -393,7 +394,7 @@ function refershToken(r) {
 function setTokenParams(r) {
     clearTokenParams(r)
     if (r.variables.oidc_token_query_params_enable == 1) {
-        r.variables.token_query_params = generateQueryParams(
+        r.variables.token_query_params = '?' + generateQueryParams(
             r.variables.oidc_token_query_params
         );
     }
@@ -525,9 +526,6 @@ function getAuthZArgs(r) {
     var authZArgs   = '?response_type=code&scope=' + r.variables.oidc_scopes +
                       '&client_id='                + r.variables.oidc_client + 
                       '&redirect_uri='             + redirectURI + 
-                      // uncomment when to need claims of access token in Auth0.
-                    //   '&audience='              + 'https://{{domain}}}/api/v2/' +
-                      '&audience='              + 'https://dev-s4i2bm4p.us.auth0.com/api/v2/' +
                       '&nonce='                    + nonceHash;
     var cookieFlags = r.variables.oidc_cookie_flags;
     r.headersOut['Set-Cookie'] = [
@@ -553,7 +551,8 @@ function getAuthZArgs(r) {
     }
 
     if (r.variables.oidc_authz_query_params_enable == 1) {
-        return generateQueryParams(r.variables.oidc_authz_query_params);
+        return authZArgs += '&' + generateQueryParams(
+            r.variables.oidc_authz_query_params);
     }
     return authZArgs;
 }
@@ -561,7 +560,7 @@ function getAuthZArgs(r) {
 // Generate custom query parameters from JSON object
 function generateQueryParams(obj) {
     var items = JSON.parse(obj);
-    var args = '?'
+    var args = ''
     for (var key in items) {
         args += key + '=' + items[key] + '&'
     }

--- a/oidc_frontend_backend.conf
+++ b/oidc_frontend_backend.conf
@@ -32,7 +32,7 @@ server {
     error_log  /var/log/nginx/error.log  debug; # Reduce severity level as required
     access_log /var/log/nginx/access.log main;
 
-    listen 443 ssl;
+    listen 12000 ssl;
     server_name nginx.auth0.test;
 
     ssl_certificate     /etc/ssl/nginx/nginx-repo.crt;
@@ -59,9 +59,12 @@ server {
     location /v1/api/example {
         auth_request    /_session_validation;
         auth_request_set $session_status $upstream_status;
-        error_page 401   @session_error;
+        if ($session_validation_enable) {
+            error_page 401 = @session_error;
+        }
 
-        auth_jwt "" token=$id_token;
+        auth_jwt "" token=$access_token;
+        #auth_jwt_key_file $oidc_jwt_keyfile;   # Enable when using filename
         auth_jwt_key_request /_jwks_uri;        # Enable when using URL
 
         proxy_set_header Authorization "Bearer $access_token";

--- a/oidc_idp.conf
+++ b/oidc_idp.conf
@@ -66,11 +66,13 @@ map $x_client_id $oidc_authz_path_params {
 }
 
 map $x_client_id $oidc_authz_query_params_enable {
-    default 0;
+    default 1;
 }
 
 map $x_client_id $oidc_authz_query_params {
-    default "";
+    default '{
+        "audience": "https://$idp_domain/api/v2/"
+    }';
 }
 
 map $x_client_id $oidc_logout_path_params_enable {

--- a/oidc_nginx_http.conf
+++ b/oidc_nginx_http.conf
@@ -39,7 +39,14 @@ map $http_x_forwarded_proto $proto {
 }
 
 map $x_client_id $post_logout_return_uri {
+    # The following examples can be replaced with a custom logout page, or
+    # complete URL to be redirected after successful logout from the IdP.
+
+    # Example 1: Redirect to the original page.
     default $redirect_base;
+
+    # Example 2: Redirect to a custom logout page
+    # default https://www.google.com;
 }
 
 map $x_client_id $return_token_to_client_on_login {

--- a/oidc_nginx_server.conf
+++ b/oidc_nginx_server.conf
@@ -108,10 +108,9 @@
         # This location is called by frontend to retrieve user info via the IDP.
         auth_request    /_session_validation;
         auth_request_set $session_status $upstream_status;
-        error_page 401 = @session_error;
-
-        auth_jwt "" token=$id_token;
-        auth_jwt_key_request /_jwks_uri;        # Enable when using URL
+        if ($session_validation_enable) {
+            error_page 401 = @session_error;
+        }
 
         proxy_ssl_server_name on; # For SNI to the IdP
         proxy_set_header Authorization "Bearer $access_token";
@@ -149,18 +148,8 @@
         add_header Set-Cookie "auth_nonce=; $oidc_cookie_flags"; 
         add_header Set-Cookie "client_id=; $oidc_cookie_flags"; 
 
-        # The following examples can be replaced with a custom logout page, or
-        # complete URL.
-
-        # Example 1: Redirect to the original page via $post_logout_return_uri.
+        # Redirect to either the original page or custom logout page.
         js_content oidc.redirectPostLogout;
-
-        # Example 2: Built-in, simple logout page
-        # default_type text/plain;
-        # return 200 "Logged out\n";
-
-        # Example 3: Custom logout page
-        # proxy_pass http://my_frontend_site/logout;
     }
 
     location @oidc_error {
@@ -171,7 +160,7 @@
     }
 
     location @session_error {
-        status_zone "OIDC session error";
+        status_zone "OIDC error: session";
         default_type application/json;
 
         # Clean cookies
@@ -180,7 +169,7 @@
         add_header Set-Cookie "auth_nonce=; $oidc_cookie_flags"; 
         add_header Set-Cookie "client_id=; $oidc_cookie_flags"; 
 
-        set $session_status '{ "session" : "invalid" }';
+        set $session_status '{ "message" : "invalid session" }';
         return 401 $session_status;
     }
 


### PR DESCRIPTION
- docker-compose port to consider running other docker containers locally
- common error/warning/info message constants
- comment for access token validation
- frontend app port and session management before calling proxied API.
- fix: session management
- OIDC core for query params for authZ endpoint
- Sample customer query parameter for authZ endpoint